### PR TITLE
Add `try_clone` to `Body`.

### DIFF
--- a/kube-client/src/client/body.rs
+++ b/kube-client/src/client/body.rs
@@ -53,6 +53,18 @@ impl Body {
     pub async fn collect_bytes(self) -> Result<Bytes, crate::Error> {
         Ok(self.collect().await?.to_bytes())
     }
+
+    /// Tries to clone a [`Body`] when it's [`Kind::Once`].
+    ///
+    /// Useful when using [`tower`] `retry` middleware.
+    pub fn try_clone(&self) -> Option<Self> {
+        match &self.kind {
+            Kind::Once(bytes) => Some(Self {
+                kind: Kind::Once(bytes.clone()),
+            }),
+            Kind::Wrap(_) => None,
+        }
+    }
 }
 
 impl From<Bytes> for Body {


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/private/issues/625

Adds a `try_clone` method to `Body` so we can use [`tower retry`](https://docs.rs/tower/latest/tower/retry/trait.Policy.html).